### PR TITLE
feat: add SK prefix for query

### DIFF
--- a/lambda/mainHandler.ts
+++ b/lambda/mainHandler.ts
@@ -10,7 +10,7 @@ import {
   tableMap,
 } from "../models/tableDecorator";
 import { ProgressMessage } from "../models/progressMessage";
-import { PlayerData, PlayerProgress } from "../models/playerData";
+import { PlayerData, PlayerProgress, Prefix } from "../models/playerData";
 import {
   SQSBatchItemFailure,
   SQSBatchResponse,
@@ -81,7 +81,7 @@ async function updateProgress(
       TableName: playerDataTableName,
       Key: {
         [playerDataPk]: playerId,
-        [playerDataSk]: progressId,
+        [playerDataSk]: Prefix.progress + progressId,
       },
       UpdateExpression:
         "SET #progress = if_not_exists(progress, :zero) + :progressIncrement," +
@@ -125,7 +125,7 @@ async function updateProgress(
     TableName: playerDataTableName,
     Key: {
       [playerDataPk]: playerId,
-      [playerDataSk]: progressId,
+      [playerDataSk]: Prefix.progress + progressId,
     },
   };
 
@@ -150,10 +150,7 @@ async function updateProgress(
     return;
   }
 
-  for (const {
-    achievementId,
-    requiredAmount,
-  } of Items as AchievementData[]) {
+  for (const { achievementId, requiredAmount } of Items as AchievementData[]) {
     if (requiredAmount > progress) {
       return;
     }
@@ -162,7 +159,7 @@ async function updateProgress(
       TableName: tableMap.get(PlayerData)!,
       Item: {
         [playerDataPk]: playerId,
-        [playerDataSk]: achievementId,
+        [playerDataSk]: Prefix.achievement + achievementId,
         achievedAt: timeStamp,
       },
       ConditionExpression: `attribute_not_exists(${keyMap

--- a/models/playerData.ts
+++ b/models/playerData.ts
@@ -20,3 +20,8 @@ export class PlayerProgress extends PlayerData {
   progress: number;
   lastUpdated: number;
 }
+
+export enum Prefix {
+  achievement = "achievement_",
+  progress = "progress_",
+}


### PR DESCRIPTION
*Description of changes:*
Add prefix for SK, `achievement_` and `progress_`, for query PlayerData table. Prefix won't appear in outHandler, yet if you query table directly, you would have to trim SK to get actual IDs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
